### PR TITLE
fix(release): refactor the workflows and trigger a simulation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,30 @@
+
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+options:
+  commits:
+    filters:
+      Type:
+        - feat
+        - fix
+        - perf
+        - refactor
+        - chore
+  commit_groups:
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      chore: Chores
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,10 @@
+name: Changelog
+on:
+  workflow_run:
+    workflows: ["Tag"]
+    types:
+      - completed
+jobs:
+  call-changelog-workflow:
+    uses: JetBrains/actions/.github/workflows/changelog.yaml@main
+    secrets: inherit

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,14 +1,14 @@
-name: Module Releaser
+name: Tag
 
 on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.tf'
+      - '!examples/**'
 
 jobs:
   call-tag-workflow:
     uses: JetBrains/actions/.github/workflows/tag.yaml@main
-    secrets: inherit
-  call-changelog-workflow:
-    uses: JetBrains/actions/.github/workflows/changelog.yaml@main
     secrets: inherit

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 /**
-* A declarative helm chart deployment.
-* Ref:
+* The entrypoint for this Module.
 */
 
 locals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 /*
-* This file defines the public output interface for this Module.
+* This is the public output interface for this Module.
 */
 
 output "charts_info" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 /*
-* This file define the public input interface for this Module.
+* This is the public input interface for this Module.
 */
 
 variable "charts" {


### PR DESCRIPTION
## Description

In this PR, I am decoupling the release logic because the GitHub Actions does not support chaining and triggering at run time of dependant workflows.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update